### PR TITLE
chore: bump version to 0.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-llm-accessor",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A developer-friendly, configurable LLM client supporting multiple providers, chat, and vision",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Changes

- Bump package version from 0.0.1 to 0.0.2 to match the GitHub release

## Purpose
This version bump aligns the package.json version with the GitHub release v0.0.2 that was created for the repository information addition.