### PR TITLE
fix: correct repository URLs in package.json for semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/easynet-world/7135-easy-llm-cli.git"
+    "url": "git+https://github.com/easynet-world/7135-easy-llm-accessor.git"
   },
-  "homepage": "https://github.com/easynet-world/7135-easy-llm-cli#readme",
+  "homepage": "https://github.com/easynet-world/7135-easy-llm-accessor#readme",
   "bugs": {
-    "url": "https://github.com/easynet-world/7135-easy-llm-cli/issues"
+    "url": "https://github.com/easynet-world/7135-easy-llm-accessor/issues"
   },
   "funding": {
     "type": "github",


### PR DESCRIPTION
## 🔧 Fix Repository URLs

This PR fixes the incorrect repository URLs in package.json that were causing semantic-release to fail.

### 🐛 Issue
- semantic-release was trying to create releases for the wrong repository ()
- This caused the release workflow to fail with repository not found errors

### ✅ Fix
- Updated repository URL from  to 
- Updated homepage URL to match
- Updated bugs URL to match

### 🔄 Next Steps
After merging this fix:
1. The release workflow should work correctly
2. semantic-release will create releases for the correct repository
3. We can then trigger a proper release for the Ollama provider features

This fix is required before we can successfully release v1.1.0.