### PR TITLE
fix: correct cache method names in Ollama provider tests

### DIFF
--- a/__tests__/ollama-provider.test.js
+++ b/__tests__/ollama-provider.test.js
@@ -466,11 +466,11 @@ describe('OllamaProvider', () => {
 
   describe('Cache Management', () => {
     test('should clear all caches', () => {
-      expect(() => provider.clearCaches()).not.toThrow();
+      expect(() => provider.clearAllCaches()).not.toThrow();
     });
 
     test('should get cache statistics', () => {
-      const stats = provider.getCacheStats();
+      const stats = provider.getAllCacheStats();
       expect(stats).toBeDefined();
     });
   });


### PR DESCRIPTION
Fix Ollama provider tests to use correct CacheMixin method names. All tests now passing.